### PR TITLE
fix(jit): implement pow and float modulo

### DIFF
--- a/rust/lumen-codegen/src/ir.rs
+++ b/rust/lumen-codegen/src/ir.rs
@@ -166,6 +166,27 @@ pub fn lower_cell<M: Module>(
     )?;
     let str_drop_ref =
         declare_helper_func(module, &mut func, "jit_rt_string_drop", &[types::I64], &[])?;
+    let fmod_ref = declare_helper_func(
+        module,
+        &mut func,
+        "jit_rt_fmod",
+        &[types::F64, types::F64],
+        &[types::F64],
+    )?;
+    let pow_float_ref = declare_helper_func(
+        module,
+        &mut func,
+        "jit_rt_pow_float",
+        &[types::F64, types::F64],
+        &[types::F64],
+    )?;
+    let pow_int_ref = declare_helper_func(
+        module,
+        &mut func,
+        "jit_rt_pow_int",
+        &[types::I64, types::I64],
+        &[types::I64],
+    )?;
 
     // Suppress unused-variable warnings for helpers not yet used in all paths.
     let _ = str_clone_ref;
@@ -180,9 +201,19 @@ pub fn lower_cell<M: Module>(
     // Track the semantic type of each variable for type-aware code generation.
     let mut var_types: HashMap<u32, JitVarType> = HashMap::new();
 
-    // Pre-scan constants to determine which registers receive float/string values.
-    let mut float_regs: std::collections::HashSet<u8> = std::collections::HashSet::new();
-    let mut string_regs: std::collections::HashSet<u8> = std::collections::HashSet::new();
+    // Pre-scan registers to determine which ones need F64 or String storage.
+    let mut float_regs: std::collections::HashSet<u8> = cell
+        .params
+        .iter()
+        .filter(|param| param.ty == "Float")
+        .map(|param| param.register)
+        .collect();
+    let mut string_regs: std::collections::HashSet<u8> = cell
+        .params
+        .iter()
+        .filter(|param| param.ty == "String")
+        .map(|param| param.register)
+        .collect();
     for inst in &cell.instructions {
         if inst.op == OpCode::LoadK {
             let bx = inst.bx() as usize;
@@ -194,6 +225,29 @@ pub fn lower_cell<M: Module>(
                     string_regs.insert(inst.a);
                 }
                 _ => {}
+            }
+        }
+    }
+
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for inst in &cell.instructions {
+            let dest = inst.a;
+            let mark_dest_float = match inst.op {
+                OpCode::Move | OpCode::MoveOwn => float_regs.contains(&inst.b),
+                OpCode::Add
+                | OpCode::Sub
+                | OpCode::Mul
+                | OpCode::Div
+                | OpCode::Mod
+                | OpCode::FloorDiv
+                | OpCode::Pow => float_regs.contains(&inst.b) || float_regs.contains(&inst.c),
+                OpCode::Neg => float_regs.contains(&inst.b),
+                _ => false,
+            };
+            if mark_dest_float && float_regs.insert(dest) {
+                changed = true;
             }
         }
     }
@@ -528,7 +582,21 @@ pub fn lower_cell<M: Module>(
             OpCode::Mod => {
                 let lhs = use_var(&mut builder, &vars, inst.b);
                 let rhs = use_var(&mut builder, &vars, inst.c);
-                let res = builder.ins().srem(lhs, rhs);
+                let is_float = is_float_op(&var_types, inst.b, inst.c);
+                let res = if is_float {
+                    let call = builder.ins().call(fmod_ref, &[lhs, rhs]);
+                    builder.inst_results(call)[0]
+                } else {
+                    builder.ins().srem(lhs, rhs)
+                };
+                var_types.insert(
+                    inst.a as u32,
+                    if is_float {
+                        JitVarType::Float
+                    } else {
+                        JitVarType::Int
+                    },
+                );
                 def_var(&mut builder, &vars, inst.a, res);
             }
             OpCode::Neg => {
@@ -570,13 +638,17 @@ pub fn lower_cell<M: Module>(
                 def_var(&mut builder, &vars, inst.a, res);
             }
             OpCode::Pow => {
+                let lhs = use_var(&mut builder, &vars, inst.b);
+                let rhs = use_var(&mut builder, &vars, inst.c);
                 let is_float = is_float_op(&var_types, inst.b, inst.c);
                 if is_float {
-                    let zero = builder.ins().f64const(0.0);
+                    let call = builder.ins().call(pow_float_ref, &[lhs, rhs]);
+                    let zero = builder.inst_results(call)[0];
                     var_types.insert(inst.a as u32, JitVarType::Float);
                     def_var(&mut builder, &vars, inst.a, zero);
                 } else {
-                    let zero = builder.ins().iconst(types::I64, 0);
+                    let call = builder.ins().call(pow_int_ref, &[lhs, rhs]);
+                    let zero = builder.inst_results(call)[0];
                     var_types.insert(inst.a as u32, JitVarType::Int);
                     def_var(&mut builder, &vars, inst.a, zero);
                 }

--- a/rust/lumen-codegen/src/jit.rs
+++ b/rust/lumen-codegen/src/jit.rs
@@ -154,6 +154,31 @@ fn register_string_helpers(builder: &mut JITBuilder) {
     builder.symbol("jit_rt_string_drop", jit_rt_string_drop as *const u8);
 }
 
+/// Float modulo, matching Rust `f64` remainder semantics.
+extern "C" fn jit_rt_fmod(a: f64, b: f64) -> f64 {
+    a % b
+}
+
+/// Floating-point exponentiation.
+extern "C" fn jit_rt_pow_float(base: f64, exp: f64) -> f64 {
+    base.powf(exp)
+}
+
+/// Integer exponentiation with saturating-negative exponent behavior.
+extern "C" fn jit_rt_pow_int(base: i64, exp: i64) -> i64 {
+    if exp < 0 {
+        0
+    } else {
+        base.pow(exp as u32)
+    }
+}
+
+fn register_math_helpers(builder: &mut JITBuilder) {
+    builder.symbol("jit_rt_fmod", jit_rt_fmod as *const u8);
+    builder.symbol("jit_rt_pow_float", jit_rt_pow_float as *const u8);
+    builder.symbol("jit_rt_pow_int", jit_rt_pow_int as *const u8);
+}
+
 // ---------------------------------------------------------------------------
 // Execution profiling
 // ---------------------------------------------------------------------------
@@ -308,6 +333,8 @@ struct CompiledFunction {
     param_count: usize,
     /// True if the function returns a heap-allocated string pointer.
     returns_string: bool,
+    /// True if the function returns an F64 value.
+    returns_float: bool,
 }
 
 // Safety: The function pointers are valid for the lifetime of the JITModule
@@ -417,8 +444,9 @@ impl JitEngine {
         )
         .map_err(|e| JitError::ModuleError(format!("JITBuilder creation failed: {e}")))?;
 
-        // Register string runtime helper symbols so JIT code can call them.
+        // Register runtime helper symbols so JIT code can call them.
         register_string_helpers(&mut builder);
+        register_math_helpers(&mut builder);
 
         let mut jit_module = JITModule::new(builder);
         let pointer_type = jit_module.isa().pointer_type();
@@ -440,6 +468,7 @@ impl JitEngine {
                     fn_ptr,
                     param_count: func.param_count,
                     returns_string: func.returns_string,
+                    returns_float: func.returns_float,
                 },
             );
             self.stats.cells_compiled += 1;
@@ -474,8 +503,13 @@ impl JitEngine {
         // valid for the lifetime of the JITModule (which we own). The
         // caller guarantees the signature matches.
         let result = unsafe {
-            let code_fn: fn() -> i64 = std::mem::transmute(fn_ptr);
-            code_fn()
+            if compiled.returns_float {
+                let code_fn: fn() -> f64 = std::mem::transmute(fn_ptr);
+                code_fn().to_bits() as i64
+            } else {
+                let code_fn: fn() -> i64 = std::mem::transmute(fn_ptr);
+                code_fn()
+            }
         };
         Ok(result)
     }
@@ -492,8 +526,13 @@ impl JitEngine {
         self.stats.executions += 1;
 
         let result = unsafe {
-            let code_fn: fn(i64) -> i64 = std::mem::transmute(fn_ptr);
-            code_fn(arg)
+            if compiled.returns_float {
+                let code_fn: fn(i64) -> f64 = std::mem::transmute(fn_ptr);
+                code_fn(arg).to_bits() as i64
+            } else {
+                let code_fn: fn(i64) -> i64 = std::mem::transmute(fn_ptr);
+                code_fn(arg)
+            }
         };
         Ok(result)
     }
@@ -515,8 +554,13 @@ impl JitEngine {
         self.stats.executions += 1;
 
         let result = unsafe {
-            let code_fn: fn(i64, i64) -> i64 = std::mem::transmute(fn_ptr);
-            code_fn(arg1, arg2)
+            if compiled.returns_float {
+                let code_fn: fn(i64, i64) -> f64 = std::mem::transmute(fn_ptr);
+                code_fn(arg1, arg2).to_bits() as i64
+            } else {
+                let code_fn: fn(i64, i64) -> i64 = std::mem::transmute(fn_ptr);
+                code_fn(arg1, arg2)
+            }
         };
         Ok(result)
     }
@@ -539,8 +583,13 @@ impl JitEngine {
         self.stats.executions += 1;
 
         let result = unsafe {
-            let code_fn: fn(i64, i64, i64) -> i64 = std::mem::transmute(fn_ptr);
-            code_fn(arg1, arg2, arg3)
+            if compiled.returns_float {
+                let code_fn: fn(i64, i64, i64) -> f64 = std::mem::transmute(fn_ptr);
+                code_fn(arg1, arg2, arg3).to_bits() as i64
+            } else {
+                let code_fn: fn(i64, i64, i64) -> i64 = std::mem::transmute(fn_ptr);
+                code_fn(arg1, arg2, arg3)
+            }
         };
         Ok(result)
     }
@@ -682,6 +731,7 @@ struct JitLoweredFunction {
     func_id: FuncId,
     param_count: usize,
     returns_string: bool,
+    returns_float: bool,
 }
 
 /// Lower an entire LIR module into Cranelift IR inside the given `JITModule`.
@@ -784,11 +834,17 @@ fn lower_module_jit(
             .as_deref()
             .map(|s| s == "String")
             .unwrap_or(false);
+        let ret_is_float = cell
+            .returns
+            .as_deref()
+            .map(|s| s == "Float")
+            .unwrap_or(false);
         lowered.functions.push(JitLoweredFunction {
             name: cell.name.clone(),
             func_id,
             param_count: cell.params.len(),
             returns_string: ret_is_string,
+            returns_float: ret_is_float,
         });
     }
 
@@ -1545,6 +1601,79 @@ mod tests {
         assert_eq!(engine.execute_jit_unary("choose", 5).unwrap(), 100);
         assert_eq!(engine.execute_jit_unary("choose", -1).unwrap(), 50);
         assert_eq!(engine.execute_jit_unary("choose", 0).unwrap(), 50);
+    }
+
+    #[test]
+    fn jit_opcode_pow_int() {
+        let lir = make_module_with_cells(vec![LirCell {
+            name: "pow_int".to_string(),
+            params: Vec::new(),
+            returns: Some("Int".to_string()),
+            registers: 3,
+            constants: vec![],
+            instructions: vec![
+                Instruction::abc(OpCode::LoadInt, 0, 2, 0),
+                Instruction::abc(OpCode::LoadInt, 1, 10, 0),
+                Instruction::abc(OpCode::Pow, 2, 0, 1),
+                Instruction::abc(OpCode::Return, 2, 1, 0),
+            ],
+            effect_handler_metas: Vec::new(),
+        }]);
+
+        let mut engine = JitEngine::new(CodegenSettings::default(), 0);
+        engine.compile_module(&lir).expect("compile");
+
+        assert_eq!(engine.execute_jit_nullary("pow_int").unwrap(), 1024);
+    }
+
+    #[test]
+    fn jit_opcode_pow_float() {
+        let lir = make_module_with_cells(vec![LirCell {
+            name: "pow_float".to_string(),
+            params: Vec::new(),
+            returns: Some("Float".to_string()),
+            registers: 3,
+            constants: vec![Constant::Float(3.0), Constant::Float(2.0)],
+            instructions: vec![
+                Instruction::abx(OpCode::LoadK, 0, 0),
+                Instruction::abx(OpCode::LoadK, 1, 1),
+                Instruction::abc(OpCode::Pow, 2, 0, 1),
+                Instruction::abc(OpCode::Return, 2, 1, 0),
+            ],
+            effect_handler_metas: Vec::new(),
+        }]);
+
+        let mut engine = JitEngine::new(CodegenSettings::default(), 0);
+        engine.compile_module(&lir).expect("compile");
+
+        let raw = engine.execute_jit_nullary("pow_float").expect("execute");
+        let result = f64::from_bits(raw as u64);
+        assert!((result - 9.0).abs() < 1e-10, "expected 9.0, got {result}");
+    }
+
+    #[test]
+    fn jit_opcode_mod_float() {
+        let lir = make_module_with_cells(vec![LirCell {
+            name: "mod_float".to_string(),
+            params: Vec::new(),
+            returns: Some("Float".to_string()),
+            registers: 3,
+            constants: vec![Constant::Float(10.0), Constant::Float(3.0)],
+            instructions: vec![
+                Instruction::abx(OpCode::LoadK, 0, 0),
+                Instruction::abx(OpCode::LoadK, 1, 1),
+                Instruction::abc(OpCode::Mod, 2, 0, 1),
+                Instruction::abc(OpCode::Return, 2, 1, 0),
+            ],
+            effect_handler_metas: Vec::new(),
+        }]);
+
+        let mut engine = JitEngine::new(CodegenSettings::default(), 0);
+        engine.compile_module(&lir).expect("compile");
+
+        let raw = engine.execute_jit_nullary("mod_float").expect("execute");
+        let result = f64::from_bits(raw as u64);
+        assert!((result - 1.0).abs() < 1e-10, "expected 1.0, got {result}");
     }
 
     #[test]


### PR DESCRIPTION
Part of milestone: v0.5.0 JIT stable.

This PR closes two opcode-completeness gaps in the Cranelift JIT path:
-  now lowers to real integer/float exponentiation helpers instead of stubbing to zero
-  now uses float remainder lowering when either operand is float

It also fixes float-result execution in the JIT engine so float-returning cells are surfaced as raw bits consistently for the runtime/tests.

Validated with targeted opcode regression tests.