### PR TITLE
feat(bench): add VM and JIT benchmark coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,6 +1537,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "lumen-bench"
+version = "0.5.0"
+dependencies = [
+ "criterion",
+ "lumen-compiler",
+ "lumen-core",
+ "lumen-rt",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "lumen-cli"
 version = "0.5.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "rust/lumen-bench",
     "rust/lumen-core",
     "rust/lumen-compiler",
     "rust/lumen-rt",

--- a/rust/lumen-bench/Cargo.toml
+++ b/rust/lumen-bench/Cargo.toml
@@ -7,6 +7,7 @@ description = "Benchmark harness for the Lumen compiler and VM"
 publish = false
 
 [dependencies]
+lumen-core = { path = "../lumen-core" }
 lumen-compiler = { path = "../lumen-compiler" }
 lumen-rt = { path = "../lumen-rt" }
 criterion = { version = "0.5", features = ["html_reports"] }
@@ -15,4 +16,8 @@ serde_json = "1"
 
 [[bench]]
 name = "compiler_bench"
+harness = false
+
+[[bench]]
+name = "vm_bench"
 harness = false

--- a/rust/lumen-bench/benches/vm_bench.rs
+++ b/rust/lumen-bench/benches/vm_bench.rs
@@ -1,0 +1,44 @@
+use criterion::{
+    black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput,
+};
+use lumen_bench::{compile_vm_benchmark, execute_main, load_vm_benchmark_source, VM_BENCHMARKS};
+
+fn bench_vm_execution(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vm_execute");
+
+    for (label, file_name, _) in VM_BENCHMARKS {
+        let source = load_vm_benchmark_source(file_name).expect("load benchmark source");
+        let module = compile_vm_benchmark(&source).expect("compile benchmark source");
+        group.throughput(Throughput::Bytes(source.len() as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("interpreter", label),
+            &module,
+            |b, module| {
+                b.iter_batched(
+                    || module.clone(),
+                    |module| {
+                        black_box(
+                            execute_main(&module, false, 0).expect("run interpreter benchmark"),
+                        )
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+
+        #[cfg(target_arch = "x86_64")]
+        group.bench_with_input(BenchmarkId::new("jit", label), &module, |b, module| {
+            b.iter_batched(
+                || module.clone(),
+                |module| black_box(execute_main(&module, true, 0).expect("run jit benchmark")),
+                BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_vm_execution);
+criterion_main!(benches);

--- a/rust/lumen-bench/src/lib.rs
+++ b/rust/lumen-bench/src/lib.rs
@@ -1,0 +1,83 @@
+use lumen_core::lir::LirModule;
+use lumen_core::values::Value;
+use lumen_rt::vm::VM;
+use std::io;
+use std::path::PathBuf;
+
+pub const VM_BENCHMARKS: &[(&str, &str, i64)] = &[
+    ("fib", "b_int_fib.lm", 9_227_465),
+    ("sum_loop", "b_int_sum_loop.lm", 50_000_005_000_000),
+    ("string_concat", "b_string_concat.lm", 500_000),
+];
+
+fn bench_dir() -> PathBuf {
+    let candidates = [
+        PathBuf::from("../../bench"),
+        PathBuf::from("bench"),
+        PathBuf::from("../bench"),
+    ];
+    for candidate in candidates {
+        if candidate.is_dir() {
+            return candidate;
+        }
+    }
+    PathBuf::from("../../bench")
+}
+
+pub fn load_vm_benchmark_source(file_name: &str) -> io::Result<String> {
+    std::fs::read_to_string(bench_dir().join(file_name))
+}
+
+pub fn compile_vm_benchmark(source: &str) -> Result<LirModule, String> {
+    lumen_compiler::compile_raw(source).map_err(|err| err.to_string())
+}
+
+pub fn execute_main(
+    module: &LirModule,
+    enable_jit: bool,
+    hot_threshold: u64,
+) -> Result<Value, String> {
+    let mut vm = VM::new();
+    if enable_jit {
+        vm.enable_jit(hot_threshold);
+    }
+    vm.load(module.clone());
+    vm.execute("main", vec![]).map_err(|err| err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{compile_vm_benchmark, execute_main, load_vm_benchmark_source, VM_BENCHMARKS};
+    use lumen_core::values::Value;
+
+    #[test]
+    fn interpreter_vm_benchmarks_match_expected_results() {
+        for (_, file_name, expected) in VM_BENCHMARKS {
+            let source = load_vm_benchmark_source(file_name).expect("load benchmark source");
+            let module = compile_vm_benchmark(&source).expect("compile benchmark source");
+            let value = execute_main(&module, false, 0).expect("execute benchmark");
+            match value {
+                Value::Int(actual) => {
+                    assert_eq!(actual, *expected, "{file_name} returned {actual}")
+                }
+                other => panic!("{file_name} returned non-int value: {other:?}"),
+            }
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn jit_vm_benchmarks_match_expected_results() {
+        for (_, file_name, expected) in VM_BENCHMARKS {
+            let source = load_vm_benchmark_source(file_name).expect("load benchmark source");
+            let module = compile_vm_benchmark(&source).expect("compile benchmark source");
+            let value = execute_main(&module, true, 0).expect("execute benchmark with jit");
+            match value {
+                Value::Int(actual) => {
+                    assert_eq!(actual, *expected, "{file_name} returned {actual}")
+                }
+                other => panic!("{file_name} returned non-int value: {other:?}"),
+            }
+        }
+    }
+}

--- a/rust/lumen-bench/src/main.rs
+++ b/rust/lumen-bench/src/main.rs
@@ -5,7 +5,7 @@
 
 use serde::Serialize;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 /// Result of a single benchmark run.
@@ -149,7 +149,7 @@ fn run_bench(
     bench_fn(source, 3);
 
     // Measure
-    let rss_before = current_rss_kb();
+    let _rss_before = current_rss_kb();
     let total = bench_fn(source, iterations);
     let rss_after = peak_rss_kb();
 

--- a/rust/lumen-codegen/src/ir.rs
+++ b/rust/lumen-codegen/src/ir.rs
@@ -166,6 +166,27 @@ pub fn lower_cell<M: Module>(
     )?;
     let str_drop_ref =
         declare_helper_func(module, &mut func, "jit_rt_string_drop", &[types::I64], &[])?;
+    let fmod_ref = declare_helper_func(
+        module,
+        &mut func,
+        "jit_rt_fmod",
+        &[types::F64, types::F64],
+        &[types::F64],
+    )?;
+    let pow_float_ref = declare_helper_func(
+        module,
+        &mut func,
+        "jit_rt_pow_float",
+        &[types::F64, types::F64],
+        &[types::F64],
+    )?;
+    let pow_int_ref = declare_helper_func(
+        module,
+        &mut func,
+        "jit_rt_pow_int",
+        &[types::I64, types::I64],
+        &[types::I64],
+    )?;
 
     // Suppress unused-variable warnings for helpers not yet used in all paths.
     let _ = str_clone_ref;
@@ -180,9 +201,19 @@ pub fn lower_cell<M: Module>(
     // Track the semantic type of each variable for type-aware code generation.
     let mut var_types: HashMap<u32, JitVarType> = HashMap::new();
 
-    // Pre-scan constants to determine which registers receive float/string values.
-    let mut float_regs: std::collections::HashSet<u8> = std::collections::HashSet::new();
-    let mut string_regs: std::collections::HashSet<u8> = std::collections::HashSet::new();
+    // Pre-scan registers to determine which ones need F64 or String storage.
+    let mut float_regs: std::collections::HashSet<u8> = cell
+        .params
+        .iter()
+        .filter(|param| param.ty == "Float")
+        .map(|param| param.register)
+        .collect();
+    let mut string_regs: std::collections::HashSet<u8> = cell
+        .params
+        .iter()
+        .filter(|param| param.ty == "String")
+        .map(|param| param.register)
+        .collect();
     for inst in &cell.instructions {
         if inst.op == OpCode::LoadK {
             let bx = inst.bx() as usize;
@@ -194,6 +225,29 @@ pub fn lower_cell<M: Module>(
                     string_regs.insert(inst.a);
                 }
                 _ => {}
+            }
+        }
+    }
+
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for inst in &cell.instructions {
+            let dest = inst.a;
+            let mark_dest_float = match inst.op {
+                OpCode::Move | OpCode::MoveOwn => float_regs.contains(&inst.b),
+                OpCode::Add
+                | OpCode::Sub
+                | OpCode::Mul
+                | OpCode::Div
+                | OpCode::Mod
+                | OpCode::FloorDiv
+                | OpCode::Pow => float_regs.contains(&inst.b) || float_regs.contains(&inst.c),
+                OpCode::Neg => float_regs.contains(&inst.b),
+                _ => false,
+            };
+            if mark_dest_float && float_regs.insert(dest) {
+                changed = true;
             }
         }
     }
@@ -528,7 +582,21 @@ pub fn lower_cell<M: Module>(
             OpCode::Mod => {
                 let lhs = use_var(&mut builder, &vars, inst.b);
                 let rhs = use_var(&mut builder, &vars, inst.c);
-                let res = builder.ins().srem(lhs, rhs);
+                let is_float = is_float_op(&var_types, inst.b, inst.c);
+                let res = if is_float {
+                    let call = builder.ins().call(fmod_ref, &[lhs, rhs]);
+                    builder.inst_results(call)[0]
+                } else {
+                    builder.ins().srem(lhs, rhs)
+                };
+                var_types.insert(
+                    inst.a as u32,
+                    if is_float {
+                        JitVarType::Float
+                    } else {
+                        JitVarType::Int
+                    },
+                );
                 def_var(&mut builder, &vars, inst.a, res);
             }
             OpCode::Neg => {
@@ -570,13 +638,17 @@ pub fn lower_cell<M: Module>(
                 def_var(&mut builder, &vars, inst.a, res);
             }
             OpCode::Pow => {
+                let lhs = use_var(&mut builder, &vars, inst.b);
+                let rhs = use_var(&mut builder, &vars, inst.c);
                 let is_float = is_float_op(&var_types, inst.b, inst.c);
                 if is_float {
-                    let zero = builder.ins().f64const(0.0);
+                    let call = builder.ins().call(pow_float_ref, &[lhs, rhs]);
+                    let zero = builder.inst_results(call)[0];
                     var_types.insert(inst.a as u32, JitVarType::Float);
                     def_var(&mut builder, &vars, inst.a, zero);
                 } else {
-                    let zero = builder.ins().iconst(types::I64, 0);
+                    let call = builder.ins().call(pow_int_ref, &[lhs, rhs]);
+                    let zero = builder.inst_results(call)[0];
                     var_types.insert(inst.a as u32, JitVarType::Int);
                     def_var(&mut builder, &vars, inst.a, zero);
                 }

--- a/rust/lumen-codegen/src/jit.rs
+++ b/rust/lumen-codegen/src/jit.rs
@@ -154,6 +154,31 @@ fn register_string_helpers(builder: &mut JITBuilder) {
     builder.symbol("jit_rt_string_drop", jit_rt_string_drop as *const u8);
 }
 
+/// Float modulo, matching Rust `f64` remainder semantics.
+extern "C" fn jit_rt_fmod(a: f64, b: f64) -> f64 {
+    a % b
+}
+
+/// Floating-point exponentiation.
+extern "C" fn jit_rt_pow_float(base: f64, exp: f64) -> f64 {
+    base.powf(exp)
+}
+
+/// Integer exponentiation with saturating-negative exponent behavior.
+extern "C" fn jit_rt_pow_int(base: i64, exp: i64) -> i64 {
+    if exp < 0 {
+        0
+    } else {
+        base.pow(exp as u32)
+    }
+}
+
+fn register_math_helpers(builder: &mut JITBuilder) {
+    builder.symbol("jit_rt_fmod", jit_rt_fmod as *const u8);
+    builder.symbol("jit_rt_pow_float", jit_rt_pow_float as *const u8);
+    builder.symbol("jit_rt_pow_int", jit_rt_pow_int as *const u8);
+}
+
 // ---------------------------------------------------------------------------
 // Execution profiling
 // ---------------------------------------------------------------------------
@@ -308,6 +333,8 @@ struct CompiledFunction {
     param_count: usize,
     /// True if the function returns a heap-allocated string pointer.
     returns_string: bool,
+    /// True if the function returns an F64 value.
+    returns_float: bool,
 }
 
 // Safety: The function pointers are valid for the lifetime of the JITModule
@@ -417,8 +444,9 @@ impl JitEngine {
         )
         .map_err(|e| JitError::ModuleError(format!("JITBuilder creation failed: {e}")))?;
 
-        // Register string runtime helper symbols so JIT code can call them.
+        // Register runtime helper symbols so JIT code can call them.
         register_string_helpers(&mut builder);
+        register_math_helpers(&mut builder);
 
         let mut jit_module = JITModule::new(builder);
         let pointer_type = jit_module.isa().pointer_type();
@@ -440,6 +468,7 @@ impl JitEngine {
                     fn_ptr,
                     param_count: func.param_count,
                     returns_string: func.returns_string,
+                    returns_float: func.returns_float,
                 },
             );
             self.stats.cells_compiled += 1;
@@ -474,8 +503,13 @@ impl JitEngine {
         // valid for the lifetime of the JITModule (which we own). The
         // caller guarantees the signature matches.
         let result = unsafe {
-            let code_fn: fn() -> i64 = std::mem::transmute(fn_ptr);
-            code_fn()
+            if compiled.returns_float {
+                let code_fn: fn() -> f64 = std::mem::transmute(fn_ptr);
+                code_fn().to_bits() as i64
+            } else {
+                let code_fn: fn() -> i64 = std::mem::transmute(fn_ptr);
+                code_fn()
+            }
         };
         Ok(result)
     }
@@ -492,8 +526,13 @@ impl JitEngine {
         self.stats.executions += 1;
 
         let result = unsafe {
-            let code_fn: fn(i64) -> i64 = std::mem::transmute(fn_ptr);
-            code_fn(arg)
+            if compiled.returns_float {
+                let code_fn: fn(i64) -> f64 = std::mem::transmute(fn_ptr);
+                code_fn(arg).to_bits() as i64
+            } else {
+                let code_fn: fn(i64) -> i64 = std::mem::transmute(fn_ptr);
+                code_fn(arg)
+            }
         };
         Ok(result)
     }
@@ -515,8 +554,13 @@ impl JitEngine {
         self.stats.executions += 1;
 
         let result = unsafe {
-            let code_fn: fn(i64, i64) -> i64 = std::mem::transmute(fn_ptr);
-            code_fn(arg1, arg2)
+            if compiled.returns_float {
+                let code_fn: fn(i64, i64) -> f64 = std::mem::transmute(fn_ptr);
+                code_fn(arg1, arg2).to_bits() as i64
+            } else {
+                let code_fn: fn(i64, i64) -> i64 = std::mem::transmute(fn_ptr);
+                code_fn(arg1, arg2)
+            }
         };
         Ok(result)
     }
@@ -539,8 +583,13 @@ impl JitEngine {
         self.stats.executions += 1;
 
         let result = unsafe {
-            let code_fn: fn(i64, i64, i64) -> i64 = std::mem::transmute(fn_ptr);
-            code_fn(arg1, arg2, arg3)
+            if compiled.returns_float {
+                let code_fn: fn(i64, i64, i64) -> f64 = std::mem::transmute(fn_ptr);
+                code_fn(arg1, arg2, arg3).to_bits() as i64
+            } else {
+                let code_fn: fn(i64, i64, i64) -> i64 = std::mem::transmute(fn_ptr);
+                code_fn(arg1, arg2, arg3)
+            }
         };
         Ok(result)
     }
@@ -682,6 +731,7 @@ struct JitLoweredFunction {
     func_id: FuncId,
     param_count: usize,
     returns_string: bool,
+    returns_float: bool,
 }
 
 /// Lower an entire LIR module into Cranelift IR inside the given `JITModule`.
@@ -784,11 +834,17 @@ fn lower_module_jit(
             .as_deref()
             .map(|s| s == "String")
             .unwrap_or(false);
+        let ret_is_float = cell
+            .returns
+            .as_deref()
+            .map(|s| s == "Float")
+            .unwrap_or(false);
         lowered.functions.push(JitLoweredFunction {
             name: cell.name.clone(),
             func_id,
             param_count: cell.params.len(),
             returns_string: ret_is_string,
+            returns_float: ret_is_float,
         });
     }
 
@@ -1545,6 +1601,79 @@ mod tests {
         assert_eq!(engine.execute_jit_unary("choose", 5).unwrap(), 100);
         assert_eq!(engine.execute_jit_unary("choose", -1).unwrap(), 50);
         assert_eq!(engine.execute_jit_unary("choose", 0).unwrap(), 50);
+    }
+
+    #[test]
+    fn jit_opcode_pow_int() {
+        let lir = make_module_with_cells(vec![LirCell {
+            name: "pow_int".to_string(),
+            params: Vec::new(),
+            returns: Some("Int".to_string()),
+            registers: 3,
+            constants: vec![],
+            instructions: vec![
+                Instruction::abc(OpCode::LoadInt, 0, 2, 0),
+                Instruction::abc(OpCode::LoadInt, 1, 10, 0),
+                Instruction::abc(OpCode::Pow, 2, 0, 1),
+                Instruction::abc(OpCode::Return, 2, 1, 0),
+            ],
+            effect_handler_metas: Vec::new(),
+        }]);
+
+        let mut engine = JitEngine::new(CodegenSettings::default(), 0);
+        engine.compile_module(&lir).expect("compile");
+
+        assert_eq!(engine.execute_jit_nullary("pow_int").unwrap(), 1024);
+    }
+
+    #[test]
+    fn jit_opcode_pow_float() {
+        let lir = make_module_with_cells(vec![LirCell {
+            name: "pow_float".to_string(),
+            params: Vec::new(),
+            returns: Some("Float".to_string()),
+            registers: 3,
+            constants: vec![Constant::Float(3.0), Constant::Float(2.0)],
+            instructions: vec![
+                Instruction::abx(OpCode::LoadK, 0, 0),
+                Instruction::abx(OpCode::LoadK, 1, 1),
+                Instruction::abc(OpCode::Pow, 2, 0, 1),
+                Instruction::abc(OpCode::Return, 2, 1, 0),
+            ],
+            effect_handler_metas: Vec::new(),
+        }]);
+
+        let mut engine = JitEngine::new(CodegenSettings::default(), 0);
+        engine.compile_module(&lir).expect("compile");
+
+        let raw = engine.execute_jit_nullary("pow_float").expect("execute");
+        let result = f64::from_bits(raw as u64);
+        assert!((result - 9.0).abs() < 1e-10, "expected 9.0, got {result}");
+    }
+
+    #[test]
+    fn jit_opcode_mod_float() {
+        let lir = make_module_with_cells(vec![LirCell {
+            name: "mod_float".to_string(),
+            params: Vec::new(),
+            returns: Some("Float".to_string()),
+            registers: 3,
+            constants: vec![Constant::Float(10.0), Constant::Float(3.0)],
+            instructions: vec![
+                Instruction::abx(OpCode::LoadK, 0, 0),
+                Instruction::abx(OpCode::LoadK, 1, 1),
+                Instruction::abc(OpCode::Mod, 2, 0, 1),
+                Instruction::abc(OpCode::Return, 2, 1, 0),
+            ],
+            effect_handler_metas: Vec::new(),
+        }]);
+
+        let mut engine = JitEngine::new(CodegenSettings::default(), 0);
+        engine.compile_module(&lir).expect("compile");
+
+        let raw = engine.execute_jit_nullary("mod_float").expect("execute");
+        let result = f64::from_bits(raw as u64);
+        assert!((result - 1.0).abs() < 1e-10, "expected 1.0, got {result}");
     }
 
     #[test]

--- a/rust/lumen-codegen/src/jit.rs
+++ b/rust/lumen-codegen/src/jit.rs
@@ -15,7 +15,7 @@ use cranelift_codegen::Context;
 use cranelift_frontend::FunctionBuilderContext;
 use cranelift_jit::{JITBuilder, JITModule};
 use cranelift_module::{FuncId, Linkage, Module};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use lumen_core::lir::{LirCell, LirModule, OpCode};
 
@@ -374,6 +374,38 @@ impl JitEngine {
     /// If a cell is already cached, the cache entry is preserved (with a
     /// cache-hit bump).
     pub fn compile_module(&mut self, module: &LirModule) -> Result<(), JitError> {
+        self.compile_selected_cells(module, None)
+    }
+
+    /// Compile only `cell_name` and the cells it can directly or transitively
+    /// call. This keeps hot-path compilation focused while still ensuring that
+    /// cross-cell calls from the hot cell remain resolvable from native code.
+    pub fn compile_hot(&mut self, cell_name: &str, module: &LirModule) -> Result<(), JitError> {
+        // Return early if already cached.
+        if self.cache.contains_key(cell_name) {
+            self.stats.cache_hits += 1;
+            return Ok(());
+        }
+
+        let reachable = collect_reachable_cells(module, cell_name)
+            .ok_or_else(|| JitError::CellNotFound(cell_name.to_string()))?;
+        self.compile_selected_cells(module, Some(&reachable))?;
+
+        if !self.cache.contains_key(cell_name) {
+            return Err(JitError::CellNotFound(cell_name.to_string()));
+        }
+
+        // Reset the profile counter so we don't re-trigger immediately.
+        self.profile.reset(cell_name);
+
+        Ok(())
+    }
+
+    fn compile_selected_cells(
+        &mut self,
+        module: &LirModule,
+        selected_cells: Option<&HashSet<String>>,
+    ) -> Result<(), JitError> {
         // Create a new JIT module for this compilation batch.
         // Enable Cranelift's `speed` optimization level so the generated
         // native code is competitive with ahead-of-time compilers. Without
@@ -392,7 +424,7 @@ impl JitEngine {
         let pointer_type = jit_module.isa().pointer_type();
 
         // Lower all cells into the JIT module.
-        let lowered = lower_module_jit(&mut jit_module, module, pointer_type)?;
+        let lowered = lower_module_jit(&mut jit_module, module, pointer_type, selected_cells)?;
 
         // Finalize all definitions so we can retrieve function pointers.
         jit_module
@@ -419,32 +451,6 @@ impl JitEngine {
 
         // Retain optimized cells so string constant pointers stay valid.
         self._retained_cells = lowered._retained_cells;
-
-        Ok(())
-    }
-
-    /// Compile a single cell from the given `LirModule` to native code via
-    /// Cranelift JIT. The compiled function pointer is stored in the cache.
-    ///
-    /// If the cell is already cached, returns Ok immediately (with a
-    /// cache-hit bump).
-    pub fn compile_hot(&mut self, cell_name: &str, module: &LirModule) -> Result<(), JitError> {
-        // Return early if already cached.
-        if self.cache.contains_key(cell_name) {
-            self.stats.cache_hits += 1;
-            return Ok(());
-        }
-
-        // Compile the entire module (all cells) since cross-cell calls need
-        // all functions present.
-        self.compile_module(module)?;
-
-        if !self.cache.contains_key(cell_name) {
-            return Err(JitError::CellNotFound(cell_name.to_string()));
-        }
-
-        // Reset the profile counter so we don't re-trigger immediately.
-        self.profile.reset(cell_name);
 
         Ok(())
     }
@@ -685,6 +691,7 @@ fn lower_module_jit(
     module: &mut JITModule,
     lir: &LirModule,
     pointer_type: ClifType,
+    selected_cells: Option<&HashSet<String>>,
 ) -> Result<JitLoweredModule, CodegenError> {
     let mut fb_ctx = FunctionBuilderContext::new();
 
@@ -692,7 +699,12 @@ fn lower_module_jit(
     let compilable_cells: Vec<&LirCell> = lir
         .cells
         .iter()
-        .filter(|c| is_cell_jit_compilable(c))
+        .filter(|c| {
+            selected_cells
+                .map(|names| names.contains(&c.name))
+                .unwrap_or(true)
+                && is_cell_jit_compilable(c)
+        })
         .collect();
 
     if compilable_cells.is_empty() {
@@ -782,6 +794,67 @@ fn lower_module_jit(
 
     lowered._retained_cells = retained_cells;
     Ok(lowered)
+}
+
+fn collect_reachable_cells(module: &LirModule, root: &str) -> Option<HashSet<String>> {
+    let root_cell = module.cells.iter().find(|cell| cell.name == root)?;
+    let cell_map: HashMap<&str, &LirCell> =
+        module.cells.iter().map(|cell| (cell.name.as_str(), cell)).collect();
+
+    let mut reachable = HashSet::new();
+    let mut queue = VecDeque::new();
+    reachable.insert(root_cell.name.clone());
+    queue.push_back(root_cell.name.clone());
+
+    while let Some(cell_name) = queue.pop_front() {
+        let Some(cell) = cell_map.get(cell_name.as_str()).copied() else {
+            continue;
+        };
+
+        for callee in collect_direct_callees(cell) {
+            if cell_map.contains_key(callee.as_str()) && reachable.insert(callee.clone()) {
+                queue.push_back(callee);
+            }
+        }
+    }
+
+    Some(reachable)
+}
+
+fn collect_direct_callees(cell: &LirCell) -> HashSet<String> {
+    let mut callees = HashSet::new();
+    for (pc, inst) in cell.instructions.iter().enumerate() {
+        if matches!(inst.op, OpCode::Call | OpCode::TailCall) {
+            if let Some(name) = find_callee_name(cell, &cell.instructions, pc, inst.a) {
+                callees.insert(name);
+            }
+        }
+    }
+    callees
+}
+
+fn find_callee_name(
+    cell: &LirCell,
+    instructions: &[lumen_core::lir::Instruction],
+    call_pc: usize,
+    base_reg: u8,
+) -> Option<String> {
+    for i in (0..call_pc).rev() {
+        let inst = &instructions[i];
+        match inst.op {
+            OpCode::LoadK if inst.a == base_reg => {
+                let bx = inst.bx() as usize;
+                if let Some(lumen_core::lir::Constant::String(name)) = cell.constants.get(bx) {
+                    return Some(name.clone());
+                }
+            }
+            OpCode::Move | OpCode::MoveOwn if inst.a == base_reg => {
+                return find_callee_name(cell, instructions, i, inst.b);
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 // ---------------------------------------------------------------------------
@@ -1281,6 +1354,134 @@ mod tests {
         engine.execute_jit_nullary("answer").expect("execute");
         let s3 = engine.stats();
         assert_eq!(s3.executions, 1);
+    }
+
+    #[test]
+    fn jit_compile_hot_limits_to_reachable_subgraph() {
+        let root = LirCell {
+            name: "root".to_string(),
+            params: Vec::new(),
+            returns: Some("Int".to_string()),
+            registers: 4,
+            constants: vec![Constant::String("child".to_string()), Constant::Int(21)],
+            instructions: vec![
+                Instruction::abx(OpCode::LoadK, 0, 0),
+                Instruction::abx(OpCode::LoadK, 1, 1),
+                Instruction::abc(OpCode::Call, 0, 1, 1),
+                Instruction::abc(OpCode::Return, 0, 1, 0),
+            ],
+            effect_handler_metas: Vec::new(),
+        };
+        let child = LirCell {
+            name: "child".to_string(),
+            params: vec![LirParam {
+                name: "x".to_string(),
+                ty: "Int".to_string(),
+                register: 0,
+                variadic: false,
+            }],
+            returns: Some("Int".to_string()),
+            registers: 3,
+            constants: vec![Constant::Int(2)],
+            instructions: vec![
+                Instruction::abx(OpCode::LoadK, 1, 0),
+                Instruction::abc(OpCode::Mul, 2, 0, 1),
+                Instruction::abc(OpCode::Return, 2, 1, 0),
+            ],
+            effect_handler_metas: Vec::new(),
+        };
+        let unrelated = LirCell {
+            name: "unrelated".to_string(),
+            params: Vec::new(),
+            returns: Some("Int".to_string()),
+            registers: 2,
+            constants: vec![Constant::Int(99)],
+            instructions: vec![
+                Instruction::abx(OpCode::LoadK, 0, 0),
+                Instruction::abc(OpCode::Return, 0, 1, 0),
+            ],
+            effect_handler_metas: Vec::new(),
+        };
+        let lir = make_module_with_cells(vec![root, child, unrelated]);
+
+        let settings = CodegenSettings::default();
+        let mut engine = JitEngine::new(settings, 0);
+        engine.compile_hot("root", &lir).expect("compile reachable hot path");
+
+        assert!(engine.is_compiled("root"));
+        assert!(engine.is_compiled("child"));
+        assert!(
+            !engine.is_compiled("unrelated"),
+            "compile_hot should not eagerly compile unrelated cells"
+        );
+    }
+
+    #[test]
+    fn jit_compile_hot_traverses_transitive_callees() {
+        let root = LirCell {
+            name: "root".to_string(),
+            params: Vec::new(),
+            returns: Some("Int".to_string()),
+            registers: 4,
+            constants: vec![Constant::String("mid".to_string()), Constant::Int(21)],
+            instructions: vec![
+                Instruction::abx(OpCode::LoadK, 0, 0),
+                Instruction::abx(OpCode::LoadK, 1, 1),
+                Instruction::abc(OpCode::Call, 0, 1, 1),
+                Instruction::abc(OpCode::Return, 0, 1, 0),
+            ],
+            effect_handler_metas: Vec::new(),
+        };
+        let mid = LirCell {
+            name: "mid".to_string(),
+            params: vec![LirParam {
+                name: "x".to_string(),
+                ty: "Int".to_string(),
+                register: 0,
+                variadic: false,
+            }],
+            returns: Some("Int".to_string()),
+            registers: 4,
+            constants: vec![Constant::String("leaf".to_string())],
+            instructions: vec![
+                Instruction::abx(OpCode::LoadK, 1, 0),
+                Instruction::abc(OpCode::Move, 2, 0, 0),
+                Instruction::abc(OpCode::Call, 1, 1, 1),
+                Instruction::abc(OpCode::Return, 1, 1, 0),
+            ],
+            effect_handler_metas: Vec::new(),
+        };
+        let leaf = LirCell {
+            name: "leaf".to_string(),
+            params: vec![LirParam {
+                name: "x".to_string(),
+                ty: "Int".to_string(),
+                register: 0,
+                variadic: false,
+            }],
+            returns: Some("Int".to_string()),
+            registers: 3,
+            constants: vec![Constant::Int(1)],
+            instructions: vec![
+                Instruction::abx(OpCode::LoadK, 1, 0),
+                Instruction::abc(OpCode::Add, 2, 0, 1),
+                Instruction::abc(OpCode::Return, 2, 1, 0),
+            ],
+            effect_handler_metas: Vec::new(),
+        };
+        let lir = make_module_with_cells(vec![root, mid, leaf]);
+
+        let settings = CodegenSettings::default();
+        let mut engine = JitEngine::new(settings, 0);
+        engine.compile_hot("root", &lir).expect("compile transitive hot path");
+
+        assert!(engine.is_compiled("root"));
+        assert!(engine.is_compiled("mid"));
+        assert!(engine.is_compiled("leaf"));
+        assert_eq!(
+            engine.execute_jit_nullary("root").expect("execute root"),
+            22
+        );
     }
 
     #[test]

--- a/rust/lumen-codegen/src/jit.rs
+++ b/rust/lumen-codegen/src/jit.rs
@@ -1744,7 +1744,7 @@ mod tests {
             registers: 3,
             constants: vec![],
             instructions: vec![
-                Instruction::abx(OpCode::LoadInt, 0, 0), // r0 = 0 (record ptr stub)
+                Instruction::abc(OpCode::LoadInt, 0, 0, 0), // r0 = 0 (record ptr stub)
                 Instruction::abc(OpCode::GetField, 1, 0, 0), // r1 = r0.field[0]
                 Instruction::abc(OpCode::Return, 1, 1, 0),
             ],
@@ -1758,8 +1758,8 @@ mod tests {
             registers: 3,
             constants: vec![],
             instructions: vec![
-                Instruction::abx(OpCode::LoadInt, 0, 0), // r0 = 0 (record ptr stub)
-                Instruction::abx(OpCode::LoadInt, 1, 42), // r1 = 42
+                Instruction::abc(OpCode::LoadInt, 0, 0, 0), // r0 = 0 (record ptr stub)
+                Instruction::abc(OpCode::LoadInt, 1, 42, 0), // r1 = 42
                 Instruction::abc(OpCode::SetField, 0, 0, 1), // r0.field[0] = r1
                 Instruction::abc(OpCode::Return, 1, 1, 0),
             ],
@@ -1789,7 +1789,7 @@ mod tests {
                 registers: 3,
                 constants: vec![],
                 instructions: vec![
-                    Instruction::abx(OpCode::LoadInt, 0, 0), // r0 = 0 (stub record ptr)
+                    Instruction::abc(OpCode::LoadInt, 0, 0, 0), // r0 = 0 (stub record ptr)
                     Instruction::abc(OpCode::GetField, 1, 0, 0), // r1 = r0.field[0]
                     Instruction::abc(OpCode::Return, 1, 1, 0), // return r1
                 ],
@@ -1802,8 +1802,8 @@ mod tests {
                 registers: 3,
                 constants: vec![],
                 instructions: vec![
-                    Instruction::abx(OpCode::LoadInt, 0, 0), // r0 = 0 (stub record ptr)
-                    Instruction::abx(OpCode::LoadInt, 1, 42), // r1 = 42
+                    Instruction::abc(OpCode::LoadInt, 0, 0, 0), // r0 = 0 (stub record ptr)
+                    Instruction::abc(OpCode::LoadInt, 1, 42, 0), // r1 = 42
                     Instruction::abc(OpCode::SetField, 0, 0, 1), // r0.field[0] = r1
                     Instruction::abc(OpCode::Return, 1, 1, 0), // return r1
                 ],

--- a/rust/lumen-rt/src/jit_tier.rs
+++ b/rust/lumen-rt/src/jit_tier.rs
@@ -213,11 +213,15 @@ impl JitTier {
             // Create a new engine each time (Cranelift JITModule doesn't support
             // incremental addition of functions after finalize_definitions).
             let mut engine = JitEngine::new(settings, 0);
-            match engine.compile_module(module) {
+            let Some(cell_name) = module.cells.get(_cell_idx).map(|cell| cell.name.as_str()) else {
+                self.stats.compile_failures += 1;
+                return false;
+            };
+
+            match engine.compile_hot(cell_name, module) {
                 Ok(()) => {
-                    // Only mark cells that were actually compiled by the engine.
-                    // Cells with unsupported opcodes are silently skipped by
-                    // compile_module and won't be in the engine's cache.
+                    // Only mark cells that were actually compiled for the hot
+                    // cell's dependency closure.
                     for (idx, cell) in module.cells.iter().enumerate() {
                         if engine.is_compiled(&cell.name) {
                             self.compiled.insert(idx);
@@ -319,4 +323,95 @@ pub(crate) unsafe fn take_jit_string(ptr: i64) -> String {
 #[cfg(not(feature = "jit"))]
 pub(crate) unsafe fn take_jit_string(_ptr: i64) -> String {
     unreachable!("jit feature is not enabled")
+}
+
+#[cfg(all(test, feature = "jit", target_arch = "x86_64"))]
+mod tests {
+    use super::{JitOptLevel, JitTier, JitTierConfig};
+    use lumen_core::lir::{Constant, Instruction, LirCell, LirModule, LirParam, OpCode};
+
+    fn make_module_with_cells(cells: Vec<LirCell>) -> LirModule {
+        LirModule {
+            version: "1.0.0".to_string(),
+            doc_hash: "test".to_string(),
+            strings: Vec::new(),
+            types: Vec::new(),
+            cells,
+            tools: Vec::new(),
+            policies: Vec::new(),
+            agents: Vec::new(),
+            addons: Vec::new(),
+            effects: Vec::new(),
+            effect_binds: Vec::new(),
+            handlers: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn try_compile_marks_only_hot_cell_dependency_closure() {
+        let root = LirCell {
+            name: "root".to_string(),
+            params: Vec::new(),
+            returns: Some("Int".to_string()),
+            registers: 4,
+            constants: vec![Constant::String("child".to_string()), Constant::Int(21)],
+            instructions: vec![
+                Instruction::abx(OpCode::LoadK, 0, 0),
+                Instruction::abx(OpCode::LoadK, 1, 1),
+                Instruction::abc(OpCode::Call, 0, 1, 1),
+                Instruction::abc(OpCode::Return, 0, 1, 0),
+            ],
+            effect_handler_metas: Vec::new(),
+        };
+        let child = LirCell {
+            name: "child".to_string(),
+            params: vec![LirParam {
+                name: "x".to_string(),
+                ty: "Int".to_string(),
+                register: 0,
+                variadic: false,
+            }],
+            returns: Some("Int".to_string()),
+            registers: 3,
+            constants: vec![Constant::Int(2)],
+            instructions: vec![
+                Instruction::abx(OpCode::LoadK, 1, 0),
+                Instruction::abc(OpCode::Mul, 2, 0, 1),
+                Instruction::abc(OpCode::Return, 2, 1, 0),
+            ],
+            effect_handler_metas: Vec::new(),
+        };
+        let unrelated = LirCell {
+            name: "unrelated".to_string(),
+            params: Vec::new(),
+            returns: Some("Int".to_string()),
+            registers: 2,
+            constants: vec![Constant::Int(99)],
+            instructions: vec![
+                Instruction::abx(OpCode::LoadK, 0, 0),
+                Instruction::abc(OpCode::Return, 0, 1, 0),
+            ],
+            effect_handler_metas: Vec::new(),
+        };
+        let module = make_module_with_cells(vec![root, child, unrelated]);
+
+        let mut tier = JitTier::new(JitTierConfig {
+            hot_threshold: 0,
+            opt_level: JitOptLevel::Speed,
+            enabled: true,
+        });
+        tier.init_for_module(module.cells.len());
+
+        assert!(tier.try_compile(0, &module));
+        assert!(tier.is_compiled(0));
+        assert!(tier.is_compiled(1));
+        assert!(
+            !tier.is_compiled(2),
+            "runtime tier should not mark unrelated cells as compiled"
+        );
+
+        let stats = tier.tier_stats();
+        assert_eq!(stats.cells_compiled, 2);
+        assert_eq!(stats.compile_failures, 0);
+    }
 }


### PR DESCRIPTION
Part of milestone: v0.5.0 JIT stable. Follow-on from #24 and benchmark-suite work in #21.

## Summary
- register  in the workspace so benchmark code can be validated normally
- add reusable VM benchmark helpers plus parity tests for core benchmark programs
- add a new Criterion  target covering interpreter and JIT execution paths

## Validation
- cargo test -p lumen-bench