### PR TITLE
fix(jit): preserve hot roots across engine rebuilds

### DIFF
--- a/rust/lumen-codegen/src/jit.rs
+++ b/rust/lumen-codegen/src/jit.rs
@@ -428,6 +428,35 @@ impl JitEngine {
         Ok(())
     }
 
+    /// Compile the union of multiple hot roots and their reachable callees.
+    pub fn compile_hot_roots(
+        &mut self,
+        cell_names: &[String],
+        module: &LirModule,
+    ) -> Result<(), JitError> {
+        if cell_names.is_empty() {
+            return Ok(());
+        }
+
+        let mut reachable = HashSet::new();
+        for cell_name in cell_names {
+            let closure = collect_reachable_cells(module, cell_name)
+                .ok_or_else(|| JitError::CellNotFound(cell_name.clone()))?;
+            reachable.extend(closure);
+        }
+
+        self.compile_selected_cells(module, Some(&reachable))?;
+
+        for cell_name in cell_names {
+            if !self.cache.contains_key(cell_name) {
+                return Err(JitError::CellNotFound(cell_name.clone()));
+            }
+            self.profile.reset(cell_name);
+        }
+
+        Ok(())
+    }
+
     fn compile_selected_cells(
         &mut self,
         module: &LirModule,
@@ -460,6 +489,7 @@ impl JitEngine {
             .map_err(|e| JitError::ModuleError(format!("finalize_definitions failed: {e}")))?;
 
         // Retrieve and cache function pointers.
+        self.cache.clear();
         for func in &lowered.functions {
             let fn_ptr = jit_module.get_finalized_function(func.func_id);
             self.cache.insert(
@@ -854,8 +884,11 @@ fn lower_module_jit(
 
 fn collect_reachable_cells(module: &LirModule, root: &str) -> Option<HashSet<String>> {
     let root_cell = module.cells.iter().find(|cell| cell.name == root)?;
-    let cell_map: HashMap<&str, &LirCell> =
-        module.cells.iter().map(|cell| (cell.name.as_str(), cell)).collect();
+    let cell_map: HashMap<&str, &LirCell> = module
+        .cells
+        .iter()
+        .map(|cell| (cell.name.as_str(), cell))
+        .collect();
 
     let mut reachable = HashSet::new();
     let mut queue = VecDeque::new();
@@ -1462,7 +1495,9 @@ mod tests {
 
         let settings = CodegenSettings::default();
         let mut engine = JitEngine::new(settings, 0);
-        engine.compile_hot("root", &lir).expect("compile reachable hot path");
+        engine
+            .compile_hot("root", &lir)
+            .expect("compile reachable hot path");
 
         assert!(engine.is_compiled("root"));
         assert!(engine.is_compiled("child"));
@@ -1529,7 +1564,9 @@ mod tests {
 
         let settings = CodegenSettings::default();
         let mut engine = JitEngine::new(settings, 0);
-        engine.compile_hot("root", &lir).expect("compile transitive hot path");
+        engine
+            .compile_hot("root", &lir)
+            .expect("compile transitive hot path");
 
         assert!(engine.is_compiled("root"));
         assert!(engine.is_compiled("mid"));
@@ -1537,6 +1574,96 @@ mod tests {
         assert_eq!(
             engine.execute_jit_nullary("root").expect("execute root"),
             22
+        );
+    }
+
+    #[test]
+    fn jit_compile_hot_roots_preserves_multiple_independent_hot_paths() {
+        let lir = LirModule {
+            version: "1.0.0".to_string(),
+            doc_hash: "test".to_string(),
+            strings: Vec::new(),
+            types: Vec::new(),
+            cells: vec![
+                LirCell {
+                    name: "left_root".to_string(),
+                    params: Vec::new(),
+                    returns: Some("Int".to_string()),
+                    registers: 3,
+                    constants: vec![Constant::String("left_leaf".to_string())],
+                    instructions: vec![
+                        Instruction::abx(OpCode::LoadK, 0, 0),
+                        Instruction::abc(OpCode::Call, 0, 0, 1),
+                        Instruction::abc(OpCode::Return, 0, 1, 0),
+                    ],
+                    effect_handler_metas: Vec::new(),
+                },
+                LirCell {
+                    name: "left_leaf".to_string(),
+                    params: Vec::new(),
+                    returns: Some("Int".to_string()),
+                    registers: 2,
+                    constants: vec![Constant::Int(11)],
+                    instructions: vec![
+                        Instruction::abx(OpCode::LoadK, 0, 0),
+                        Instruction::abc(OpCode::Return, 0, 1, 0),
+                    ],
+                    effect_handler_metas: Vec::new(),
+                },
+                LirCell {
+                    name: "right_root".to_string(),
+                    params: Vec::new(),
+                    returns: Some("Int".to_string()),
+                    registers: 3,
+                    constants: vec![Constant::String("right_leaf".to_string())],
+                    instructions: vec![
+                        Instruction::abx(OpCode::LoadK, 0, 0),
+                        Instruction::abc(OpCode::Call, 0, 0, 1),
+                        Instruction::abc(OpCode::Return, 0, 1, 0),
+                    ],
+                    effect_handler_metas: Vec::new(),
+                },
+                LirCell {
+                    name: "right_leaf".to_string(),
+                    params: Vec::new(),
+                    returns: Some("Int".to_string()),
+                    registers: 2,
+                    constants: vec![Constant::Int(29)],
+                    instructions: vec![
+                        Instruction::abx(OpCode::LoadK, 0, 0),
+                        Instruction::abc(OpCode::Return, 0, 1, 0),
+                    ],
+                    effect_handler_metas: Vec::new(),
+                },
+            ],
+            tools: Vec::new(),
+            policies: Vec::new(),
+            agents: Vec::new(),
+            addons: Vec::new(),
+            effects: Vec::new(),
+            effect_binds: Vec::new(),
+            handlers: Vec::new(),
+        };
+
+        let settings = CodegenSettings::default();
+        let mut engine = JitEngine::new(settings, 0);
+        engine
+            .compile_hot_roots(&["left_root".to_string(), "right_root".to_string()], &lir)
+            .expect("compile multiple hot roots");
+
+        assert!(engine.is_compiled("left_root"));
+        assert!(engine.is_compiled("left_leaf"));
+        assert!(engine.is_compiled("right_root"));
+        assert!(engine.is_compiled("right_leaf"));
+        assert_eq!(
+            engine.execute_jit_nullary("left_root").expect("left root"),
+            11
+        );
+        assert_eq!(
+            engine
+                .execute_jit_nullary("right_root")
+                .expect("right root"),
+            29
         );
     }
 
@@ -1791,7 +1918,7 @@ mod tests {
                 instructions: vec![
                     Instruction::abc(OpCode::LoadInt, 0, 0, 0), // r0 = 0 (stub record ptr)
                     Instruction::abc(OpCode::GetField, 1, 0, 0), // r1 = r0.field[0]
-                    Instruction::abc(OpCode::Return, 1, 1, 0), // return r1
+                    Instruction::abc(OpCode::Return, 1, 1, 0),  // return r1
                 ],
                 effect_handler_metas: Vec::new(),
             },
@@ -1805,7 +1932,7 @@ mod tests {
                     Instruction::abc(OpCode::LoadInt, 0, 0, 0), // r0 = 0 (stub record ptr)
                     Instruction::abc(OpCode::LoadInt, 1, 42, 0), // r1 = 42
                     Instruction::abc(OpCode::SetField, 0, 0, 1), // r0.field[0] = r1
-                    Instruction::abc(OpCode::Return, 1, 1, 0), // return r1
+                    Instruction::abc(OpCode::Return, 1, 1, 0),  // return r1
                 ],
                 effect_handler_metas: Vec::new(),
             },

--- a/rust/lumen-rt/src/jit_tier.rs
+++ b/rust/lumen-rt/src/jit_tier.rs
@@ -80,6 +80,9 @@ pub struct JitTier {
     call_counts: Vec<u64>,
     /// Per-cell eligibility cache.
     eligibility: Vec<CellEligibility>,
+    /// Roots that have crossed the hot threshold and must remain in the
+    /// rebuilt engine when new hot cells are compiled.
+    hot_roots: HashSet<usize>,
     /// Set of cell indices that have been compiled.
     compiled: HashSet<usize>,
     /// Configuration.
@@ -110,6 +113,7 @@ impl JitTier {
         Self {
             call_counts: Vec::new(),
             eligibility: Vec::new(),
+            hot_roots: HashSet::new(),
             compiled: HashSet::new(),
             config,
             #[cfg(feature = "jit")]
@@ -131,6 +135,7 @@ impl JitTier {
     pub fn init_for_module(&mut self, num_cells: usize) {
         self.call_counts.resize(num_cells, 0);
         self.eligibility.resize(num_cells, CellEligibility::Unknown);
+        self.hot_roots.clear();
         self.compiled.clear();
         self.stats = JitTierStats::default();
     }
@@ -213,21 +218,32 @@ impl JitTier {
             // Create a new engine each time (Cranelift JITModule doesn't support
             // incremental addition of functions after finalize_definitions).
             let mut engine = JitEngine::new(settings, 0);
-            let Some(cell_name) = module.cells.get(_cell_idx).map(|cell| cell.name.as_str()) else {
+            let Some(_) = module.cells.get(_cell_idx) else {
                 self.stats.compile_failures += 1;
                 return false;
             };
 
-            match engine.compile_hot(cell_name, module) {
+            let mut hot_roots = self.hot_roots.iter().copied().collect::<Vec<_>>();
+            hot_roots.push(_cell_idx);
+            hot_roots.sort_unstable();
+            hot_roots.dedup();
+            let hot_root_names = hot_roots
+                .iter()
+                .map(|idx| module.cells[*idx].name.clone())
+                .collect::<Vec<_>>();
+
+            match engine.compile_hot_roots(&hot_root_names, module) {
                 Ok(()) => {
+                    self.hot_roots = hot_roots.into_iter().collect();
+                    self.compiled.clear();
                     // Only mark cells that were actually compiled for the hot
                     // cell's dependency closure.
                     for (idx, cell) in module.cells.iter().enumerate() {
                         if engine.is_compiled(&cell.name) {
                             self.compiled.insert(idx);
-                            self.stats.cells_compiled += 1;
                         }
                     }
+                    self.stats.cells_compiled = self.compiled.len() as u64;
                     self.engine = Some(engine);
                     true
                 }
@@ -413,5 +429,79 @@ mod tests {
         let stats = tier.tier_stats();
         assert_eq!(stats.cells_compiled, 2);
         assert_eq!(stats.compile_failures, 0);
+    }
+
+    #[test]
+    fn try_compile_preserves_existing_hot_roots_across_engine_rebuilds() {
+        let left_root = LirCell {
+            name: "left_root".to_string(),
+            params: Vec::new(),
+            returns: Some("Int".to_string()),
+            registers: 3,
+            constants: vec![Constant::String("left_leaf".to_string())],
+            instructions: vec![
+                Instruction::abx(OpCode::LoadK, 0, 0),
+                Instruction::abc(OpCode::Call, 0, 0, 1),
+                Instruction::abc(OpCode::Return, 0, 1, 0),
+            ],
+            effect_handler_metas: Vec::new(),
+        };
+        let left_leaf = LirCell {
+            name: "left_leaf".to_string(),
+            params: Vec::new(),
+            returns: Some("Int".to_string()),
+            registers: 2,
+            constants: vec![Constant::Int(11)],
+            instructions: vec![
+                Instruction::abx(OpCode::LoadK, 0, 0),
+                Instruction::abc(OpCode::Return, 0, 1, 0),
+            ],
+            effect_handler_metas: Vec::new(),
+        };
+        let right_root = LirCell {
+            name: "right_root".to_string(),
+            params: Vec::new(),
+            returns: Some("Int".to_string()),
+            registers: 3,
+            constants: vec![Constant::String("right_leaf".to_string())],
+            instructions: vec![
+                Instruction::abx(OpCode::LoadK, 0, 0),
+                Instruction::abc(OpCode::Call, 0, 0, 1),
+                Instruction::abc(OpCode::Return, 0, 1, 0),
+            ],
+            effect_handler_metas: Vec::new(),
+        };
+        let right_leaf = LirCell {
+            name: "right_leaf".to_string(),
+            params: Vec::new(),
+            returns: Some("Int".to_string()),
+            registers: 2,
+            constants: vec![Constant::Int(29)],
+            instructions: vec![
+                Instruction::abx(OpCode::LoadK, 0, 0),
+                Instruction::abc(OpCode::Return, 0, 1, 0),
+            ],
+            effect_handler_metas: Vec::new(),
+        };
+        let module = make_module_with_cells(vec![left_root, left_leaf, right_root, right_leaf]);
+
+        let mut tier = JitTier::new(JitTierConfig {
+            hot_threshold: 0,
+            opt_level: JitOptLevel::Speed,
+            enabled: true,
+        });
+        tier.init_for_module(module.cells.len());
+
+        assert!(tier.try_compile(0, &module));
+        assert_eq!(tier.execute("left_root", &[]), Some(11));
+
+        assert!(tier.try_compile(2, &module));
+        assert_eq!(tier.execute("left_root", &[]), Some(11));
+        assert_eq!(tier.execute("right_root", &[]), Some(29));
+        assert!(tier.is_compiled(0));
+        assert!(tier.is_compiled(1));
+        assert!(tier.is_compiled(2));
+        assert!(tier.is_compiled(3));
+        assert_eq!(tier.tier_stats().cells_compiled, 4);
     }
 }


### PR DESCRIPTION
Part of milestone: v0.5.0 JIT stable. Follow-on from #25.

Summary:
- rebuild the JIT engine from the union of all hot roots instead of only the latest one
- clear stale codegen cache entries when a new JIT module is finalized
- add codegen and runtime regressions covering independent hot paths across rebuilds

Validation:
- cargo test -p lumen-codegen jit_compile_hot_roots_preserves_multiple_independent_hot_paths
- cargo test -p lumen-rt try_compile_preserves_existing_hot_roots_across_engine_rebuilds